### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/d29a46e5-eaeb-4db0-9b32-286cfad65168/efc0d15a-68c0-4548-942a-19b85a97167d/_apis/work/boardbadge/20884862-8ec3-41be-81eb-7d914c536bd8)](https://dev.azure.com/aiw-devops/d29a46e5-eaeb-4db0-9b32-286cfad65168/_boards/board/t/efc0d15a-68c0-4548-942a-19b85a97167d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#508. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.